### PR TITLE
Update Received Hub Dispatch Types

### DIFF
--- a/.github/workflows/generate-visualization-data.yaml
+++ b/.github/workflows/generate-visualization-data.yaml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
   repository_dispatch:
-    types: [covid-ensemble-added, rsv-ensemble-added]
+    types: [covid-ensemble-added]
 
 permissions:
   contents: write


### PR DESCRIPTION
This PR updates the repository dispatch naming for the two hubs STF supports. There was a mismatch between `ensemble-added` (this repository listening) and `ensemble-updated` (`covid19-forecast-hub` sending).