### PR TITLE
Update Pre-Commit CI To Ignore Visualization Data PRs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
-ci:
-  skip_branch_pattern: ^add-viz-v2-.*-data$
+
 
 repos:
 #####


### PR DESCRIPTION
This PR updates `pre-commit.ci` to ignore visualization data PR patterns. 

Perhaps it's worthwhile also ignoring other files from `pre-commit`, given that it routinely fails, particularly with using `detect-secrets`, given the size of certain files.