### PR TITLE
Ignore Unwanted Hub And File References

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -380,3 +380,5 @@ docs/site/
 
 *_files/
 .local_hub_copy
+covid19-forecast-hub
+rsv-forecast-hub


### PR DESCRIPTION
This PR adds `.local_hub_copy` to `.gitignore`.