### PR TITLE
Fix Name In Gitignored Local Hub Copy File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -379,6 +379,6 @@ docs/site/
 #Manifest.toml
 
 *_files/
-.local_hub_copy
+.local-hub-copy
 covid19-forecast-hub
 rsv-forecast-hub


### PR DESCRIPTION
Fixes `.local_hub_copy` &rarr; `.local-hub-copy`