### PR TITLE
Fix Gitignoring Of Weekly Summary Contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -380,7 +380,3 @@ docs/site/
 
 *_files/
 .local-hub-copy
-covid19-forecast-hub
-rsv-forecast-hub
-!weekly-summaries/covid19-forecast-hub
-!weekly-summaries/rsv-forecast-hub


### PR DESCRIPTION
Fix to make it so that `weekly-summaries/rsv-forecast-hub` and `weekly-summaries/covid19-forecast-hub` content is not `git` ignored. 

Stemmed from error here: <https://github.com/CDCgov/cfa-forecast-hub-reports/actions/runs/23009371991/job/66815192427>.

From discussion in other places:

> <https://git-scm.com/docs/gitignore> or `git help gitignore`
>
> 1) An optional prefix "!" which negates the pattern; any
matching file excluded by a previous pattern will become
included again. It is not possible to re-include a file if a parent directory of that file is excluded. Git doesn’t list excluded directories for performance reasons, so any patterns on contained files have no effect, no matter where they are defined. Put a backslash ("\") in front of the first "!" for patterns that begin with a literal "!", for example, "\!important!.txt".
> 
> 2) The slash "/" is used as the directory separator. Separators may occur at the beginning, middle or end of the .gitignore search pattern. 